### PR TITLE
CSS: better fallback stack for monospaced fonts

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -4,7 +4,7 @@ body {
   color: #333;
 }
 code {
-  font-family: "Source Code Pro", "Menlo", "DejaVu Sans Mono", monospace;
+  font-family: "Source Code Pro", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace;
   font-size: 0.875em;
 }
 .left {

--- a/src/theme/stylus/general.styl
+++ b/src/theme/stylus/general.styl
@@ -4,7 +4,7 @@ html, body {
 }
 
 code {
-    font-family: "Source Code Pro", "Menlo", "DejaVu Sans Mono", monospace;
+    font-family: "Source Code Pro", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace;
     font-size: 0.875em;
 }
 


### PR DESCRIPTION
List of system fonts (R, I, B means roman, italic and bold. Ubuntu probably comes with more fonts, but I couldn't find a list to confirm.):

```txt
Windows
----------
Consolas            R RI  B BI
Courier             R
Courier New         R RI  B BI
Lucida Console      R

Mac
----------
Andale Mono         R
Courier             R RI  B BI
Courier New         R RI  B BI
Menlo               R RI  B BI
Monaco              R

Ubuntu
----------
Ubuntu Mono         R RI  B BI
DejaVu Sans Mono    R RI  B BI
```

```css
font-family: Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace;
```

Consolas and Ubuntu are professionally designed fonts ([Lucas de Groot][1] and [Dalton Maag][2]), with true, calligraphic italic, so they go at the top of the stack.

Menlo is [based on DejaVu Sans Mono][3], the only difference being a few tweaked glyphs, so DejaVu serves as a fallback for it.

As for Courier New, other than being unreadably spindly, it's the default monospaced font in all browsers, so there's no need to include it in the stack.

The `monospace, monospace;` declaration is, by now, [a standard hack][4] that overrides some browsers' behaviour of defaulting the `monospace` elements to smaller font size. Without it, any relative font size you apply to them will be calculated from that reduced size (seems to be 13 px in all browsers).


[1]: https://en.wikipedia.org/wiki/Luc(as)_de_Groot
[2]: https://en.wikipedia.org/wiki/Dalton_Maag
[3]: http://www.leancrew.com/all-this/2009/10/the-compleat-menlovera-sans-comparison/
[4]: https://stackoverflow.com/questions/38781089/font-family-monospace-monospace